### PR TITLE
fix: Correct jsnext:main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.13",
   "description": "Used to set respose header: Content-Security-Policy",
   "main": "dist/bundle.js",
-  "jsnext:main": "src/csp.js",
+  "module": "src/index.js",
   "repository": "git@github.com:Val-istar-Guo/koa-csp.git",
   "author": "Val.istar.Guo <Val.istar.Guo@gmail.com>",
   "keywords": [


### PR DESCRIPTION
jsnext:main previously pointed to a non-existing file. Also, module seems to be the more popular option nowadays.

Closes #1