### PR TITLE
docs: Correct import

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarn add koa-csp
 
 ```javascript
 import Koa from 'koa';
-import csp from 'csp';
+import csp from 'koa-csp';
 
 const app = new Koa();
 


### PR DESCRIPTION
The example uses an import which does not match the package name.